### PR TITLE
feat: add GET /coupons/mine client + coupon selection on member purchase (desktop & mobile)

### DIFF
--- a/apps/desktop/src/pages/MemberBenefits/index.tsx
+++ b/apps/desktop/src/pages/MemberBenefits/index.tsx
@@ -10,7 +10,9 @@ import {
 import {
   plusCreatePayment,
   plusGetMe,
+  plusGetMyCoupons,
   plusGetVipCurrentLowestPrice,
+  type MyCouponItem,
   type VipCurrentLowestPriceData,
   type VipCurrentLowestPricePlan,
 } from "@soundx/services";
@@ -23,6 +25,7 @@ import {
   Layout,
   Modal,
   QRCode,
+  Select,
   Table,
   Tooltip,
   Typography,
@@ -53,6 +56,8 @@ const MemberBenefits: React.FC = () => {
     null,
   );
   const [memberPhone, setMemberPhone] = useState("");
+  const [coupons, setCoupons] = useState<MyCouponItem[]>([]);
+  const [selectedCouponCode, setSelectedCouponCode] = useState<string | undefined>();
   const [wechatQrModalOpen, setWechatQrModalOpen] = useState(false);
   const [wechatQrCode, setWechatQrCode] = useState("");
   const isElectronRuntime =
@@ -129,6 +134,29 @@ const MemberBenefits: React.FC = () => {
     };
 
     void loadPricing();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadCoupons = async () => {
+      try {
+        const res = await plusGetMyCoupons();
+        if (!mounted) return;
+        if (res.data.code === 200) {
+          const activeCoupons = (res.data.data?.data || []).filter((item) => !!item?.code);
+          setCoupons(activeCoupons);
+        }
+      } catch (error) {
+        console.warn("Failed to fetch coupons", error);
+      }
+    };
+
+    void loadCoupons();
 
     return () => {
       mounted = false;
@@ -382,6 +410,7 @@ const MemberBenefits: React.FC = () => {
       const res = await plusCreatePayment({
         userId,
         amount: selectedPlanPrice,
+        couponCode: selectedCouponCode,
         currency: "CNY",
         method,
         clientType: isElectronRuntime ? "desktop" : "web",
@@ -643,6 +672,21 @@ const MemberBenefits: React.FC = () => {
                 ) : null}
               </Card>
             </Flex>
+          </div>
+
+          <div style={{ marginBottom: 12 }}>
+            <Text>{t("memberBenefits.couponLabel", "选择优惠券")}</Text>
+            <Select
+              allowClear
+              style={{ width: "100%", marginTop: 8 }}
+              placeholder={t("memberBenefits.couponPlaceholder", "不使用优惠券") as string}
+              value={selectedCouponCode}
+              onChange={(value) => setSelectedCouponCode(value)}
+              options={coupons.map((item) => ({
+                value: item.code,
+                label: `${item.code} · -${item.discountPercent}%`,
+              }))}
+            />
           </div>
 
           <div style={{ marginTop: 8, marginBottom: 8 }}>

--- a/apps/mobile/app/member-benefits.tsx
+++ b/apps/mobile/app/member-benefits.tsx
@@ -2,7 +2,9 @@ import { AntDesign, Ionicons, MaterialIcons } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import {
   plusGetMe,
+  plusGetMyCoupons,
   plusGetVipCurrentLowestPrice,
+  type MyCouponItem,
   type VipCurrentLowestPriceData,
   type VipCurrentLowestPricePlan,
 } from "@soundx/services";
@@ -58,6 +60,8 @@ export default function MemberBenefitsScreen() {
   );
   const [pricingLoading, setPricingLoading] = useState(true);
   const [memberPhone, setMemberPhone] = useState("");
+  const [coupons, setCoupons] = useState<MyCouponItem[]>([]);
+  const [selectedCouponCode, setSelectedCouponCode] = useState<string | null>(null);
 
   const maskPhone = (value?: string | null) => {
     const normalized = String(value || "").replace(/\D/g, "");
@@ -192,6 +196,29 @@ export default function MemberBenefitsScreen() {
     };
 
     void loadMemberPhone();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadCoupons = async () => {
+      try {
+        const res = await plusGetMyCoupons();
+        if (!mounted) return;
+        if (res.data.code === 200) {
+          setCoupons((res.data.data?.data || []).filter((item) => !!item?.code));
+        }
+      } catch (error) {
+        console.warn("Failed to fetch coupons", error);
+      }
+    };
+
+    void loadCoupons();
 
     return () => {
       mounted = false;
@@ -416,6 +443,7 @@ export default function MemberBenefitsScreen() {
         selectedPlan,
         method,
         selectedPlanPrice,
+        selectedCouponCode || undefined,
       );
 
       if (res.data.code === 201 || res.data.code === 200) {
@@ -620,7 +648,28 @@ export default function MemberBenefitsScreen() {
         </View>
 
         {/* Pricing Plans */}
-        <View style={styles.dividerContainer}>
+      <View style={styles.couponSection}>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>选择优惠券</Text>
+        <TouchableOpacity
+          style={[styles.couponPicker, { borderColor: colors.border, backgroundColor: colors.card }]}
+          onPress={() => {
+            const options = [{ text: "不使用优惠券", onPress: () => setSelectedCouponCode(null) }].concat(
+              coupons.map((item) => ({
+                text: `${item.code} · -${item.discountPercent}%`,
+                onPress: () => setSelectedCouponCode(item.code),
+              })),
+            );
+            Alert.alert("选择优惠券", undefined, options as any);
+          }}
+        >
+          <Text style={{ color: colors.text }}>
+            {selectedCouponCode || "不使用优惠券"}
+          </Text>
+          <Ionicons name="chevron-down" size={16} color={colors.textSecondary} />
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.dividerContainer}>
           <Text style={[styles.dividerText, { color: colors.secondary }]}>
             {t("memberBenefitsPage.planTitle")}
           </Text>
@@ -1087,3 +1136,15 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
   },
 });
+    marginTop: 16,
+    gap: 8,
+  },
+  couponPicker: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },

--- a/apps/mobile/src/services/payments.ts
+++ b/apps/mobile/src/services/payments.ts
@@ -203,11 +203,13 @@ export const createPlusPayment = async (
   userIdRaw: string,
   plan: PaymentPlan,
   method: PaymentMethod,
-  amount: number
+  amount: number,
+  couponCode?: string
 ) => {
   const payload: CreatePaymentDto = {
     userId: normalizeUserId(userIdRaw),
     amount,
+    couponCode,
     currency: "CNY",
     method,
     clientType: "app",

--- a/packages/services/src/plus.ts
+++ b/packages/services/src/plus.ts
@@ -116,6 +116,7 @@ export type PaymentClientType = "app" | "web" | "desktop" | "mobile" | "mini";
 
 export interface CreatePaymentDto {
   userId: string;
+  couponCode?: string;
   amount: number;
   currency: string;
   method: PaymentMethod;
@@ -231,6 +232,19 @@ export interface DeletePlusMeResponse {
   deletedAt: string;
 }
 
+export interface MyCouponItem {
+  id: string;
+  code: string;
+  discountPercent: number;
+  expiresAt: string;
+  createdAt: string;
+}
+
+export interface MyCouponsResponse {
+  data: MyCouponItem[];
+  total: number;
+}
+
 // --- API Functions ---
 
 /**
@@ -322,6 +336,13 @@ export const plusGetVipCurrentLowestPrice = async () => {
  */
 export const plusGetVipStatus = async (userId: string) => {
   return plusRequest.get<ISuccessResponse<{ isVip: boolean; tier: VipTier; expiresAt: string | null }>>("/vip/status", { params: { userId } });
+};
+
+/**
+ * CouponController_getMine: Get my active coupons
+ */
+export const plusGetMyCoupons = async () => {
+  return plusRequest.get<ISuccessResponse<MyCouponsResponse>>("/coupons/mine");
 };
 
 export const plusRedeemInternalTestCode = async (


### PR DESCRIPTION
### Motivation
- Provide client support for fetching the user's available coupons and allow selecting one when creating a VIP purchase order.
- Make it possible to send a chosen coupon code to the Plus payment API so discounts can be applied server-side.

### Description
- Added typed coupon models and API helper `plusGetMyCoupons()` for `GET /coupons/mine` in `packages/services/src/plus.ts`, and extended `CreatePaymentDto` with optional `couponCode` to carry the selected coupon to the backend.
- Desktop: `apps/desktop/src/pages/MemberBenefits/index.tsx` now loads active coupons, shows a `Select` dropdown labeled "选择优惠券", and includes `couponCode` in the `plusCreatePayment` request when creating payment orders.
- Mobile: `apps/mobile/app/member-benefits.tsx` now loads active coupons and provides a simple picker UI to choose a coupon; `createPlusPayment` is called with the selected `couponCode` (and `apps/mobile/src/services/payments.ts` was updated to accept and forward `couponCode`).

### Testing
- Type check for package SDK: `pnpm -s exec tsc -p packages/services/tsconfig.json --noEmit` succeeded.
- Full desktop app type check: `pnpm -s exec tsc -p apps/desktop/tsconfig.app.json --noEmit` was executed but fails due to pre-existing, project-wide TypeScript resolution/type issues unrelated to these changes (not introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6899590388321a5536bfcc1b202f7)