### PR TITLE
Fix playback continuation at queue boundaries (mobile & desktop)

### DIFF
--- a/apps/desktop/src/store/player.ts
+++ b/apps/desktop/src/store/player.ts
@@ -376,29 +376,32 @@ export const usePlayerStore = create<PlayerState>((set, get) => {
       if (playlist.length === 0 || !currentTrack) return;
 
       const currentIndex = playlist.findIndex((t) => t.id === currentTrack.id);
-      let nextIndex = currentIndex + 1;
+      if (currentIndex === -1) return;
 
-      // Lazy Loading Trigger: if we are at the end, attempt to load more
-      if (
-        nextIndex >= playlist.length - 2 &&
+      const shouldLoadMore =
+        currentIndex + 1 >= playlist.length - 2 &&
         playlistSource?.hasMore &&
-        !isLoadingMore
-      ) {
+        !isLoadingMore;
+
+      if (shouldLoadMore) {
         await get().loadMoreSourceTracks();
       }
 
+      const latestPlaylist = get().playlist;
+      let nextIndex = currentIndex + 1;
+
       if (playMode === "shuffle") {
-        nextIndex = Math.floor(Math.random() * playlist.length);
+        nextIndex = Math.floor(Math.random() * latestPlaylist.length);
       } else if (playMode === "loop") {
-        nextIndex = nextIndex % playlist.length;
+        nextIndex = nextIndex % latestPlaylist.length;
       }
       // 注意：single 模式下手动点击"下一首"不跳回当前歌曲开头，
       // 单曲循环仅在自动播放结束时生效（见 onEnded 回调）。
 
-      if (nextIndex < playlist.length) {
-        const nextTrack = playlist[nextIndex];
-        set({ currentTrack: nextTrack, currentTime: 0, isPlaying: true });
+      if (nextIndex < latestPlaylist.length) {
+        const nextTrack = latestPlaylist[nextIndex];
         reportProgress(get(), true);
+        set({ currentTrack: nextTrack, currentTime: 0, isPlaying: true });
 
         const userId = useAuthStore.getState().user?.id;
         if (userId) {

--- a/apps/mobile/src/context/PlayerContext.tsx
+++ b/apps/mobile/src/context/PlayerContext.tsx
@@ -919,11 +919,18 @@ export const PlayerProvider: React.FC<{ children: React.ReactNode }> = ({
       return;
     }
     
-    // 非随机模式下，优先使用原生队列切歌，减少重建队列开销
+    // 非随机模式下，优先使用原生队列切歌，减少重建队列开销。
+    // 队列结束事件触发时，原生队列仍可能保留多首歌但 active index 已经在最后一首，
+    // 这时直接 skipToNext 会失败并中断业务列表兜底续播。
     const queue = await TrackPlayer.getQueue();
-    if (playModeRef.current !== PlayMode.SHUFFLE && queue.length > 1) {
-        await TrackPlayer.skipToNext();
-        return;
+    const activeIndex = await TrackPlayer.getActiveTrackIndex();
+    if (
+      playModeRef.current !== PlayMode.SHUFFLE &&
+      activeIndex !== undefined &&
+      activeIndex < queue.length - 1
+    ) {
+      await TrackPlayer.skipToNext();
+      return;
     }
 
     const current = currentTrackRef.current;


### PR DESCRIPTION
### Motivation
- Prevent playback from stopping after a few tracks by fixing edge cases when the player reaches the end of the native queue or when the playlist is extended near its end.

### Description
- Desktop: guard against invalid `currentIndex` and, when lazy-loading more tracks near the end, re-read `get().playlist` and compute `nextIndex` from the updated playlist to avoid using stale length information (`apps/desktop/src/store/player.ts`).
- Desktop: compute `shouldLoadMore` from `currentIndex` and only call `loadMoreSourceTracks()` if needed, then use the refreshed playlist for next-track selection.
- Mobile: avoid calling `TrackPlayer.skipToNext()` when the native active index is already on the last queued item by checking `activeIndex < queue.length - 1`, allowing the business-layer fallback to continue playback (`apps/mobile/src/context/PlayerContext.tsx`).
- Changes are limited to next-track / queue boundary logic to ensure reliable continuation across both platforms.

### Testing
- Ran `git diff --check` on the modified files which reported no whitespace errors and showed the intended changes (success).
- Attempted `pnpm --filter sound-x run build` which failed due to existing workspace TypeScript/module resolution issues unrelated to these logic changes (known workspace type errors, failure not caused by this PR).
- Attempted `pnpm --filter mobile exec tsc --noEmit` which also failed due to existing TypeScript type/module resolution problems in the workspace unrelated to these changes (failure not caused by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea15216fc83249160cd2f62e20686)