### PR TITLE
Add playback quality preferences (internal/external) with mobile/mini selection pages

### DIFF
--- a/apps/desktop/src/components/Player/index.tsx
+++ b/apps/desktop/src/components/Player/index.tsx
@@ -73,6 +73,7 @@ import { usePlayerStore } from "../../store/player";
 import { useSettingsStore } from "../../store/settings";
 import { useSyncStore } from "../../store/sync";
 import { formatDuration } from "../../utils/formatDuration";
+import { getCurrentPlaybackQualityPreference } from "../../utils/playbackQuality";
 import { usePlayMode } from "../../utils/playMode";
 import PlayingIndicator from "../PlayingIndicator";
 import UserSelectModal from "../UserSelectModal";
@@ -119,7 +120,7 @@ const Player: React.FC = () => {
     AudioQualityOption[]
   >([]);
   const { user, device } = useAuthStore();
-  const { updateDesktopLyric } = useSettingsStore();
+  const { general, updateDesktopLyric } = useSettingsStore();
   const desktopLyricEnable = useSettingsStore(
     (state) => state.desktopLyric.enable,
   );
@@ -173,7 +174,10 @@ const Player: React.FC = () => {
       if (!cancelled) {
         setAvailableAudioQualities(profile.options);
         setCurrentAudioQuality(
-          resolveTrackAudioQuality(profile, preferredAudioQualityRef.current),
+          resolveTrackAudioQuality(
+            profile,
+            getCurrentPlaybackQualityPreference(general),
+          ),
         );
       }
     };
@@ -183,7 +187,7 @@ const Player: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [currentTrack?.id, currentTrack?.type]);
+  }, [currentTrack?.id, currentTrack?.type, general.internalPlaybackQuality, general.externalPlaybackQuality]);
 
   const audioRef = useRef<HTMLAudioElement>(null);
   const ignoreTimeUpdate = useRef(false);
@@ -220,11 +224,19 @@ const Player: React.FC = () => {
 
   const queueListRef = useRef<QueueListRef>(null);
   const fullQueueListRef = useRef<QueueListRef>(null);
-  const preferredAudioQualityRef = useRef<AudioQuality>("lossless");
+  const preferredAudioQualityRef = useRef<AudioQuality>(
+    getCurrentPlaybackQualityPreference(general),
+  );
 
   useEffect(() => {
     preferredAudioQualityRef.current = preferredAudioQuality;
   }, [preferredAudioQuality]);
+
+  useEffect(() => {
+    const nextQuality = getCurrentPlaybackQualityPreference(general);
+    setPreferredAudioQuality(nextQuality);
+    preferredAudioQualityRef.current = nextQuality;
+  }, [general.internalPlaybackQuality, general.externalPlaybackQuality]);
 
   const handleLocateTrack = () => {
     queueListRef.current?.scrollToActive();

--- a/apps/desktop/src/pages/Settings/index.tsx
+++ b/apps/desktop/src/pages/Settings/index.tsx
@@ -29,6 +29,12 @@ import styles from "./index.module.less";
 
 const { Title, Text } = Typography;
 
+const PLAYBACK_QUALITY_OPTIONS = [
+  { labelKey: "settings.playbackQualityLossless", value: "lossless" },
+  { labelKey: "settings.playbackQualityHigh", value: "high" },
+  { labelKey: "settings.playbackQualityLow", value: "standard" },
+] as const;
+
 const PRESERVED_KEYS = new Set([
   "serverAddress",
   "selectedSourceType",
@@ -261,6 +267,34 @@ const Settings: React.FC = () => {
                 })),
               ]}
               style={{ width: 140 }}
+            />
+          </div>
+        </div>
+        <div className={styles.settingItem}>
+          <div className={styles.label}>{t("settings.internalPlaybackQuality")}</div>
+          <div className={styles.control}>
+            <Select
+              value={general.internalPlaybackQuality}
+              onChange={(val) => updateGeneral("internalPlaybackQuality", val)}
+              options={PLAYBACK_QUALITY_OPTIONS.map((option) => ({
+                label: t(option.labelKey),
+                value: option.value,
+              }))}
+              className={styles.selectMedium}
+            />
+          </div>
+        </div>
+        <div className={styles.settingItem}>
+          <div className={styles.label}>{t("settings.externalPlaybackQuality")}</div>
+          <div className={styles.control}>
+            <Select
+              value={general.externalPlaybackQuality}
+              onChange={(val) => updateGeneral("externalPlaybackQuality", val)}
+              options={PLAYBACK_QUALITY_OPTIONS.map((option) => ({
+                label: t(option.labelKey),
+                value: option.value,
+              }))}
+              className={styles.selectMedium}
             />
           </div>
         </div>

--- a/apps/desktop/src/store/settings.ts
+++ b/apps/desktop/src/store/settings.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import type { AudioQuality } from '../services/trackQuality';
 
 export interface SettingsState {
   general: {
@@ -11,6 +12,8 @@ export interface SettingsState {
     acceptSync: boolean;
     recommendationLikeRatio: number;
     experienceProgramEnabled: boolean;
+    internalPlaybackQuality: AudioQuality;
+    externalPlaybackQuality: AudioQuality;
   };
   desktopLyric: {
     enable: boolean;
@@ -49,6 +52,8 @@ export const useSettingsStore = create<SettingsState>()(
         acceptSync: true,
         recommendationLikeRatio: 50,
         experienceProgramEnabled: true,
+        internalPlaybackQuality: 'high',
+        externalPlaybackQuality: 'standard',
       },
       desktopLyric: {
         enable: false,
@@ -140,6 +145,14 @@ export const useSettingsStore = create<SettingsState>()(
         if (version <= 3) {
           if (persistedState.general && persistedState.general.experienceProgramEnabled === undefined) {
             persistedState.general.experienceProgramEnabled = true;
+          }
+        }
+        if (persistedState.general) {
+          if (persistedState.general.internalPlaybackQuality === undefined) {
+            persistedState.general.internalPlaybackQuality = 'high';
+          }
+          if (persistedState.general.externalPlaybackQuality === undefined) {
+            persistedState.general.externalPlaybackQuality = 'standard';
           }
         }
         return persistedState;

--- a/apps/desktop/src/utils/playbackQuality.ts
+++ b/apps/desktop/src/utils/playbackQuality.ts
@@ -1,0 +1,25 @@
+import type { AudioQuality } from "../services/trackQuality";
+
+const isCurrentInternalAddress = () => {
+  const activeAddress = localStorage.getItem("serverAddress") || "";
+  const sourceType = localStorage.getItem("selectedSourceType") || "AudioDock";
+  if (!activeAddress) return false;
+
+  try {
+    const configStr = localStorage.getItem(`sourceConfig_${sourceType}`);
+    if (!configStr) return false;
+    const parsed = JSON.parse(configStr);
+    const configList = Array.isArray(parsed) ? parsed : [parsed];
+    return configList.some((config) => config?.internal === activeAddress);
+  } catch {
+    return false;
+  }
+};
+
+export const getCurrentPlaybackQualityPreference = (qualities: {
+  internalPlaybackQuality: AudioQuality;
+  externalPlaybackQuality: AudioQuality;
+}) =>
+  isCurrentInternalAddress()
+    ? qualities.internalPlaybackQuality
+    : qualities.externalPlaybackQuality;

--- a/apps/mini/src/app.config.ts
+++ b/apps/mini/src/app.config.ts
@@ -17,6 +17,7 @@ export default defineAppConfig({
     'pages/folder/index',
     'pages/settings/index',
     'pages/settings/language/index',
+    'pages/settings/playback-quality/index',
     'pages/admin/index',
     'pages/source-manage/index',
     'pages/tts/tasks/index',

--- a/apps/mini/src/context/PlayerContext.tsx
+++ b/apps/mini/src/context/PlayerContext.tsx
@@ -2,6 +2,8 @@ import { Album, Artist, Playlist, TrackType, UserAudiobookHistory, UserAudiobook
 import Taro from '@tarojs/taro';
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
 import { getBaseURL } from '../utils/request';
+import { useSettings } from './SettingsContext';
+import { getCurrentPlaybackQualityPreference } from '../utils/playbackQuality';
 import {
   AudioQuality,
   AudioQualityOption,
@@ -119,6 +121,7 @@ export const usePlayer = () => useContext(PlayerContext);
 export const PlayerProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
+  const { externalPlaybackQuality } = useSettings();
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTrack, setCurrentTrack] = useState<Track | null>(null);
   const [trackList, setTrackListState] = useState<Track[]>([]);
@@ -232,6 +235,12 @@ export const PlayerProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [preferredAudioQuality]);
 
   useEffect(() => {
+    const nextQuality = getCurrentPlaybackQualityPreference({ externalPlaybackQuality });
+    setPreferredAudioQuality(nextQuality);
+    preferredAudioQualityRef.current = nextQuality;
+  }, [externalPlaybackQuality]);
+
+  useEffect(() => {
     let cancelled = false;
 
     const syncCurrentTrackQuality = async () => {
@@ -247,7 +256,10 @@ export const PlayerProvider: React.FC<{ children: React.ReactNode }> = ({
       if (cancelled) return;
       setAvailableAudioQualities(profile.options);
       setCurrentAudioQuality(
-        resolveTrackAudioQuality(profile, preferredAudioQualityRef.current),
+        resolveTrackAudioQuality(
+          profile,
+          getCurrentPlaybackQualityPreference({ externalPlaybackQuality }),
+        ),
       );
     };
 
@@ -256,7 +268,7 @@ export const PlayerProvider: React.FC<{ children: React.ReactNode }> = ({
     return () => {
       cancelled = true;
     };
-  }, [currentTrack?.id, currentTrack?.type]);
+  }, [currentTrack?.id, currentTrack?.type, externalPlaybackQuality]);
 
   useEffect(() => {
     try {
@@ -366,7 +378,8 @@ export const PlayerProvider: React.FC<{ children: React.ReactNode }> = ({
     setAvailableAudioQualities(profile.options);
     const nextQuality = resolveTrackAudioQuality(
       profile,
-      preferredQuality ?? preferredAudioQualityRef.current,
+      preferredQuality ??
+        getCurrentPlaybackQualityPreference({ externalPlaybackQuality }),
     );
 
     setCurrentAudioQuality(nextQuality);

--- a/apps/mini/src/context/SettingsContext.tsx
+++ b/apps/mini/src/context/SettingsContext.tsx
@@ -1,5 +1,6 @@
 import Taro from '@tarojs/taro';
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import type { AudioQuality } from '../services/trackQuality';
 
 interface SettingsState {
   acceptRelay: boolean;
@@ -13,6 +14,7 @@ interface SettingsState {
   recommendationLikeRatio: number;
   screenBottomInset: number;
   experienceProgramEnabled: boolean;
+  externalPlaybackQuality: AudioQuality;
 }
 
 interface SettingsContextType extends SettingsState {
@@ -35,6 +37,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     recommendationLikeRatio: 50,
     screenBottomInset: 0,
     experienceProgramEnabled: true,
+    externalPlaybackQuality: 'standard',
   });
   const [isLoading, setIsLoading] = useState(true);
 

--- a/apps/mini/src/pages/settings/index.tsx
+++ b/apps/mini/src/pages/settings/index.tsx
@@ -26,6 +26,7 @@ export default function Settings() {
     carModeEnabled,
     screenBottomInset,
     experienceProgramEnabled,
+    externalPlaybackQuality,
     updateSetting,
   } = useSettings();
   const { theme, toggleTheme } = useTheme();
@@ -90,6 +91,18 @@ export default function Settings() {
       return;
     }
     updateSetting('voiceAssistantEnabled', val);
+  };
+
+
+  const getPlaybackQualityLabel = (quality: string) => {
+    switch (quality) {
+      case 'lossless':
+        return t('settings.playbackQualityLossless');
+      case 'high':
+        return t('settings.playbackQualityHigh');
+      default:
+        return t('settings.playbackQualityLow');
+    }
   };
 
   const carModeActive = carLayoutMode || carModeEnabled;
@@ -236,6 +249,12 @@ export default function Settings() {
             t('settings.language', '语言'),
             t('settings.languageDescription', '选择应用显示语言'),
             () => Taro.navigateTo({ url: '/pages/settings/language/index' })
+          )}
+          {renderActionRow(
+            t('settings.externalPlaybackQuality'),
+            t('settings.externalPlaybackQualityDescription'),
+            () => Taro.navigateTo({ url: '/pages/settings/playback-quality/index' }),
+            getPlaybackQualityLabel(externalPlaybackQuality)
           )}
           {renderSettingRow(t('settings.autoTheme'), t('settings.autoThemeDescription'), autoTheme, (val) => updateSetting('autoTheme', val))}
           <View style={{ opacity: autoTheme ? 0.5 : 1, pointerEvents: autoTheme ? 'none' : 'auto' }}>

--- a/apps/mini/src/pages/settings/playback-quality/index.config.ts
+++ b/apps/mini/src/pages/settings/playback-quality/index.config.ts
@@ -1,3 +1,4 @@
 export default definePageConfig({
+  navigationStyle: 'custom',
   navigationBarTitleText: '播放品质'
 })

--- a/apps/mini/src/pages/settings/playback-quality/index.config.ts
+++ b/apps/mini/src/pages/settings/playback-quality/index.config.ts
@@ -1,0 +1,3 @@
+export default definePageConfig({
+  navigationBarTitleText: '播放品质'
+})

--- a/apps/mini/src/pages/settings/playback-quality/index.scss
+++ b/apps/mini/src/pages/settings/playback-quality/index.scss
@@ -1,0 +1,55 @@
+.playback-quality-settings {
+  min-height: 100vh;
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20rpx 30rpx 30rpx;
+  }
+
+  .back-btn {
+    width: 80rpx;
+    padding: 10rpx 0;
+  }
+
+  .header-title {
+    font-size: 36rpx;
+    font-weight: 600;
+  }
+
+  .list {
+    padding: 20rpx 40rpx 0;
+  }
+
+  .item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 30rpx 0;
+    border-bottom: 1rpx solid;
+  }
+
+  .item-info {
+    flex: 1;
+    margin-right: 24rpx;
+  }
+
+  .item-text {
+    display: block;
+    font-size: 32rpx;
+    font-weight: 500;
+  }
+
+  .item-description {
+    display: block;
+    margin-top: 8rpx;
+    font-size: 24rpx;
+    line-height: 34rpx;
+  }
+
+  .checkmark {
+    font-size: 36rpx;
+    font-weight: 600;
+  }
+}

--- a/apps/mini/src/pages/settings/playback-quality/index.tsx
+++ b/apps/mini/src/pages/settings/playback-quality/index.tsx
@@ -1,0 +1,98 @@
+import { Text, View } from "@tarojs/components";
+import Taro, { useLoad } from "@tarojs/taro";
+import { useTranslation } from "react-i18next";
+import { useSettings } from "../../../context/SettingsContext";
+import { useTheme } from "../../../context/ThemeContext";
+import type { AudioQuality } from "../../../services/trackQuality";
+import "./index.scss";
+
+const QUALITY_OPTIONS: Array<{
+  value: AudioQuality;
+  labelKey: string;
+  descriptionKey: string;
+}> = [
+  {
+    value: "lossless",
+    labelKey: "settings.playbackQualityLossless",
+    descriptionKey: "settings.playbackQualityLosslessDescription",
+  },
+  {
+    value: "high",
+    labelKey: "settings.playbackQualityHigh",
+    descriptionKey: "settings.playbackQualityHighDescription",
+  },
+  {
+    value: "standard",
+    labelKey: "settings.playbackQualityLow",
+    descriptionKey: "settings.playbackQualityLowDescription",
+  },
+];
+
+export default function PlaybackQualitySettings() {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const { externalPlaybackQuality, updateSetting } = useSettings();
+
+  useLoad(() => {
+    Taro.setNavigationBarTitle({
+      title: t("settings.externalPlaybackQuality"),
+    });
+    Taro.setNavigationBarColor({
+      frontColor: colors.text === "#11181C" ? "#000000" : "#ffffff",
+      backgroundColor: colors.background,
+    });
+  });
+
+  const handleSelect = async (quality: AudioQuality) => {
+    await updateSetting("externalPlaybackQuality", quality);
+    Taro.navigateBack();
+  };
+
+  return (
+    <View
+      className="playback-quality-settings"
+      style={{ backgroundColor: colors.background }}
+    >
+      <View className="header" style={{ backgroundColor: colors.background }}>
+        <View className="back-btn" onClick={() => Taro.navigateBack()}>
+          <Text
+            className="back-icon icon icon-back"
+            style={{ color: colors.text }}
+          />
+        </View>
+        <Text className="header-title" style={{ color: colors.text }}>
+          {t("settings.externalPlaybackQuality")}
+        </Text>
+        <View style={{ width: "80rpx" }} />
+      </View>
+
+      <View className="list">
+        {QUALITY_OPTIONS.map((option) => (
+          <View
+            key={option.value}
+            className="item"
+            style={{ borderBottomColor: colors.border }}
+            onClick={() => void handleSelect(option.value)}
+          >
+            <View className="item-info">
+              <Text className="item-text" style={{ color: colors.text }}>
+                {t(option.labelKey)}
+              </Text>
+              <Text
+                className="item-description"
+                style={{ color: colors.secondary }}
+              >
+                {t(option.descriptionKey)}
+              </Text>
+            </View>
+            {externalPlaybackQuality === option.value && (
+              <Text className="checkmark" style={{ color: colors.primary }}>
+                ✓
+              </Text>
+            )}
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/apps/mini/src/utils/playbackQuality.ts
+++ b/apps/mini/src/utils/playbackQuality.ts
@@ -1,0 +1,5 @@
+import type { AudioQuality } from '../services/trackQuality';
+
+export const getCurrentPlaybackQualityPreference = (qualities: {
+  externalPlaybackQuality: AudioQuality;
+}) => qualities.externalPlaybackQuality;

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -408,6 +408,7 @@ function RootLayoutNav() {
       <Stack.Screen name="scan" options={{ headerShown: false, animation: 'slide_from_bottom' }} />
       <Stack.Screen name="scan-confirm" options={{ headerShown: false, animation: 'slide_from_bottom' }} />
       <Stack.Screen name="language" options={{ headerShown: false, animation: 'slide_from_right' }} />
+      <Stack.Screen name="playback-quality" options={{ headerShown: false, animation: 'slide_from_right' }} />
       <Stack.Screen name="mv/[id]" options={{ headerShown: false, animation: 'slide_from_right' }} />
     </Stack>
   );

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -90,6 +90,7 @@ function RootLayoutNav() {
       segmentName === "scan" ||
       segmentName === "scan-confirm" ||
       segmentName === "language" ||
+      segmentName === "playback-quality" ||
       segmentName === "mv";
 
     if (!plusToken && inAuthGroup) {

--- a/apps/mobile/app/playback-quality.tsx
+++ b/apps/mobile/app/playback-quality.tsx
@@ -1,0 +1,120 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import React from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTranslation } from "react-i18next";
+import { useSettings } from "../src/context/SettingsContext";
+import { useTheme } from "../src/context/ThemeContext";
+import type { AudioQuality } from "../src/services/trackQuality";
+
+const QUALITY_OPTIONS: Array<{
+  value: AudioQuality;
+  labelKey: string;
+  descriptionKey: string;
+}> = [
+  {
+    value: "lossless",
+    labelKey: "settings.playbackQualityLossless",
+    descriptionKey: "settings.playbackQualityLosslessDescription",
+  },
+  {
+    value: "high",
+    labelKey: "settings.playbackQualityHigh",
+    descriptionKey: "settings.playbackQualityHighDescription",
+  },
+  {
+    value: "standard",
+    labelKey: "settings.playbackQualityLow",
+    descriptionKey: "settings.playbackQualityLowDescription",
+  },
+];
+
+export default function PlaybackQualityScreen() {
+  const router = useRouter();
+  const { network } = useLocalSearchParams<{ network?: string }>();
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const { internalPlaybackQuality, externalPlaybackQuality, updateSetting } =
+    useSettings();
+  const isInternal = network === "internal";
+  const selectedQuality = isInternal
+    ? internalPlaybackQuality
+    : externalPlaybackQuality;
+
+  const handleSelect = async (quality: AudioQuality) => {
+    await updateSetting(
+      isInternal ? "internalPlaybackQuality" : "externalPlaybackQuality",
+      quality,
+    );
+    router.back();
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
+        <TouchableOpacity
+          onPress={() => router.back()}
+          style={styles.backButton}
+        >
+          <Ionicons name="chevron-back" size={28} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>
+          {isInternal
+            ? t("settings.internalPlaybackQuality")
+            : t("settings.externalPlaybackQuality")}
+        </Text>
+        <View style={{ width: 40 }} />
+      </View>
+
+      <View style={styles.list}>
+        {QUALITY_OPTIONS.map((option) => (
+          <TouchableOpacity
+            key={option.value}
+            style={[styles.item, { borderBottomColor: colors.border }]}
+            onPress={() => void handleSelect(option.value)}
+          >
+            <View style={styles.itemInfo}>
+              <Text style={[styles.itemText, { color: colors.text }]}>
+                {t(option.labelKey)}
+              </Text>
+              <Text
+                style={[styles.itemDescription, { color: colors.secondary }]}
+              >
+                {t(option.descriptionKey)}
+              </Text>
+            </View>
+            {selectedQuality === option.value && (
+              <Ionicons name="checkmark" size={24} color={colors.primary} />
+            )}
+          </TouchableOpacity>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 20,
+    paddingBottom: 15,
+  },
+  backButton: { width: 40 },
+  headerTitle: { fontSize: 18, fontWeight: "600" },
+  list: { marginTop: 10, paddingHorizontal: 20 },
+  item: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 16,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  itemInfo: { flex: 1, marginRight: 16 },
+  itemText: { fontSize: 16, fontWeight: "500" },
+  itemDescription: { fontSize: 13, lineHeight: 18, marginTop: 4 },
+});

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -49,6 +49,8 @@ export default function SettingsScreen() {
     carModeEnabled,
     screenBottomInset,
     experienceProgramEnabled,
+    internalPlaybackQuality,
+    externalPlaybackQuality,
     updateSetting,
   } = useSettings();
   const [isVip, setIsVip] = React.useState(false);
@@ -237,6 +239,18 @@ export default function SettingsScreen() {
       userId: user?.id ? String(user.id) : undefined,
       deviceId: device?.id ? String(device.id) : undefined,
     });
+  };
+
+
+  const getPlaybackQualityLabel = (quality: string) => {
+    switch (quality) {
+      case "lossless":
+        return t("settings.playbackQualityLossless");
+      case "high":
+        return t("settings.playbackQualityHigh");
+      default:
+        return t("settings.playbackQualityLow");
+    }
   };
 
   const carModeActive = carLayoutMode || carModeEnabled;
@@ -438,6 +452,20 @@ export default function SettingsScreen() {
               color={colors.secondary}
             />
           </TouchableOpacity>
+
+          {renderActionRow(
+            t("settings.internalPlaybackQuality"),
+            t("settings.internalPlaybackQualityDescription"),
+            () => router.push({ pathname: "/playback-quality", params: { network: "internal" } } as any),
+            getPlaybackQualityLabel(internalPlaybackQuality),
+          )}
+
+          {renderActionRow(
+            t("settings.externalPlaybackQuality"),
+            t("settings.externalPlaybackQualityDescription"),
+            () => router.push({ pathname: "/playback-quality", params: { network: "external" } } as any),
+            getPlaybackQualityLabel(externalPlaybackQuality),
+          )}
 
           {renderSettingRow(
             t("settings.carMode"),

--- a/apps/mobile/src/context/PlayerContext.tsx
+++ b/apps/mobile/src/context/PlayerContext.tsx
@@ -64,6 +64,7 @@ import { useNotification } from "./NotificationContext";
 import { useSettings } from "./SettingsContext";
 import { useSync } from "./SyncContext";
 import { trackEvent } from "../services/tracking";
+import { getCurrentPlaybackQualityPreference } from "../utils/playbackQuality";
 
 export enum PlayMode {
   SEQUENCE = "SEQUENCE",
@@ -173,7 +174,13 @@ export const PlayerProvider: React.FC<{ children: React.ReactNode }> = ({
   const { t } = useTranslation();
   const { mode, setMode } = usePlayMode();
   const { showNotification } = useNotification();
-  const { acceptRelay, cacheEnabled, recommendationLikeRatio } = useSettings();
+  const {
+    acceptRelay,
+    cacheEnabled,
+    recommendationLikeRatio,
+    internalPlaybackQuality,
+    externalPlaybackQuality,
+  } = useSettings();
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTrack, setCurrentTrack] = useState<Track | null>(null);
   const [trackList, setTrackList] = useState<Track[]>([]);
@@ -247,6 +254,23 @@ export const PlayerProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [preferredAudioQuality]);
 
   useEffect(() => {
+    let cancelled = false;
+    const syncPreferredQuality = async () => {
+      const nextQuality = await getCurrentPlaybackQualityPreference({
+        internalPlaybackQuality,
+        externalPlaybackQuality,
+      });
+      if (cancelled) return;
+      setPreferredAudioQuality(nextQuality);
+      preferredAudioQualityRef.current = nextQuality;
+    };
+    void syncPreferredQuality();
+    return () => {
+      cancelled = true;
+    };
+  }, [internalPlaybackQuality, externalPlaybackQuality]);
+
+  useEffect(() => {
     playModeRef.current = playMode;
   }, [playMode]);
 
@@ -274,7 +298,13 @@ export const PlayerProvider: React.FC<{ children: React.ReactNode }> = ({
       if (cancelled) return;
       setAvailableAudioQualities(profile.options);
       setCurrentAudioQuality(
-        resolveTrackAudioQuality(profile, preferredAudioQualityRef.current),
+        resolveTrackAudioQuality(
+          profile,
+          await getCurrentPlaybackQualityPreference({
+            internalPlaybackQuality,
+            externalPlaybackQuality,
+          }),
+        ),
       );
     };
 
@@ -283,7 +313,7 @@ export const PlayerProvider: React.FC<{ children: React.ReactNode }> = ({
     return () => {
       cancelled = true;
     };
-  }, [currentTrack?.id, currentTrack?.type]);
+  }, [currentTrack?.id, currentTrack?.type, internalPlaybackQuality, externalPlaybackQuality]);
 
   useEffect(() => {
     let cancelled = false;
@@ -825,7 +855,11 @@ export const PlayerProvider: React.FC<{ children: React.ReactNode }> = ({
     setAvailableAudioQualities(profile.options);
     const nextQuality = resolveTrackAudioQuality(
       profile,
-      preferredQuality ?? preferredAudioQualityRef.current,
+      preferredQuality ??
+        (await getCurrentPlaybackQualityPreference({
+          internalPlaybackQuality,
+          externalPlaybackQuality,
+        })),
     );
 
     setCurrentAudioQuality(nextQuality);

--- a/apps/mobile/src/context/SettingsContext.tsx
+++ b/apps/mobile/src/context/SettingsContext.tsx
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import type { AudioQuality } from '../services/trackQuality';
 import { setTrackingEnabled } from '../services/tracking';
 
 interface SettingsState {
@@ -16,6 +17,8 @@ interface SettingsState {
   recommendationLikeRatio: number;
   eqGains: number[];
   experienceProgramEnabled: boolean;
+  internalPlaybackQuality: AudioQuality;
+  externalPlaybackQuality: AudioQuality;
 }
 
 interface SettingsContextType extends SettingsState {
@@ -40,6 +43,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     recommendationLikeRatio: 50,
     eqGains: [0, 0, 0, 0, 0],
     experienceProgramEnabled: true,
+    internalPlaybackQuality: 'high',
+    externalPlaybackQuality: 'standard',
   };
   const [settings, setSettings] = useState<SettingsState>(defaultSettings);
   const [isLoading, setIsLoading] = useState(true);

--- a/apps/mobile/src/utils/playbackQuality.ts
+++ b/apps/mobile/src/utils/playbackQuality.ts
@@ -1,0 +1,26 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import type { AudioQuality } from "../services/trackQuality";
+
+const isCurrentInternalAddress = async () => {
+  const activeAddress = (await AsyncStorage.getItem("serverAddress")) || "";
+  const sourceType = (await AsyncStorage.getItem("selectedSourceType")) || "AudioDock";
+  if (!activeAddress) return false;
+
+  try {
+    const configStr = await AsyncStorage.getItem(`sourceConfig_${sourceType}`);
+    if (!configStr) return false;
+    const parsed = JSON.parse(configStr);
+    const configList = Array.isArray(parsed) ? parsed : [parsed];
+    return configList.some((config) => config?.internal === activeAddress);
+  } catch {
+    return false;
+  }
+};
+
+export const getCurrentPlaybackQualityPreference = async (qualities: {
+  internalPlaybackQuality: AudioQuality;
+  externalPlaybackQuality: AudioQuality;
+}) =>
+  (await isCurrentInternalAddress())
+    ? qualities.internalPlaybackQuality
+    : qualities.externalPlaybackQuality;

--- a/packages/i18e/src/locales/desktop/en.json
+++ b/packages/i18e/src/locales/desktop/en.json
@@ -144,7 +144,17 @@
     "loginFirst": "Please log in first",
     "cancelLogout": "Cancel",
     "confirmLogout": "Confirm",
-    "version": "AudioDock Desktop v{{version}}"
+    "version": "AudioDock Desktop v{{version}}",
+    "internalPlaybackQuality": "Internal playback quality",
+    "externalPlaybackQuality": "External playback quality",
+    "internalPlaybackQualityDescription": "Default playback quality when connected through the internal address",
+    "externalPlaybackQualityDescription": "Default playback quality when connected through the external address",
+    "playbackQualityLossless": "Lossless",
+    "playbackQualityHigh": "High quality",
+    "playbackQualityLow": "Low quality",
+    "playbackQualityLosslessDescription": "Prefer original lossless audio and use the most bandwidth",
+    "playbackQualityHighDescription": "Prefer high-bitrate audio for a balance of quality and bandwidth",
+    "playbackQualityLowDescription": "Prefer low-bitrate audio to save external network data"
   },
   "header": {
     "pleaseLoginMemberFirst": "Please login to member account first",

--- a/packages/i18e/src/locales/desktop/zh-CN.json
+++ b/packages/i18e/src/locales/desktop/zh-CN.json
@@ -144,7 +144,17 @@
     "loginFirst": "请先登录会员账号",
     "cancelLogout": "取消",
     "confirmLogout": "确认",
-    "version": "AudioDock Desktop v{{version}}"
+    "version": "AudioDock Desktop v{{version}}",
+    "internalPlaybackQuality": "内网播放品质",
+    "externalPlaybackQuality": "外网播放品质",
+    "internalPlaybackQualityDescription": "内网连接时默认使用的播放品质",
+    "externalPlaybackQualityDescription": "外网连接时默认使用的播放品质",
+    "playbackQualityLossless": "无损品质",
+    "playbackQualityHigh": "高品质",
+    "playbackQualityLow": "低品质",
+    "playbackQualityLosslessDescription": "优先播放原始无损音频，流量占用最高",
+    "playbackQualityHighDescription": "优先播放高码率音频，兼顾音质和流量",
+    "playbackQualityLowDescription": "优先播放低码率音频，节省外网流量"
   },
   "login": {
     "title": "登录",

--- a/packages/i18e/src/locales/mobile/en.json
+++ b/packages/i18e/src/locales/mobile/en.json
@@ -137,7 +137,17 @@
     "loginMemberFirst": "Please log in with your member account first.",
     "cancelLogout": "Cancel",
     "confirmLogout": "Confirm",
-    "version": "AudioDock Mobile v{{version}}"
+    "version": "AudioDock Mobile v{{version}}",
+    "internalPlaybackQuality": "Internal playback quality",
+    "externalPlaybackQuality": "External playback quality",
+    "internalPlaybackQualityDescription": "High quality by default for internal connections",
+    "externalPlaybackQualityDescription": "Low quality by default for external connections",
+    "playbackQualityLossless": "Lossless",
+    "playbackQualityHigh": "High quality",
+    "playbackQualityLow": "Low quality",
+    "playbackQualityLosslessDescription": "Prefer original lossless audio and use the most bandwidth",
+    "playbackQualityHighDescription": "Prefer high-bitrate audio for a balance of quality and bandwidth",
+    "playbackQualityLowDescription": "Prefer low-bitrate audio to save external network data"
   },
   "player": {
     "notPlaying": "Not playing",

--- a/packages/i18e/src/locales/mobile/zh-CN.json
+++ b/packages/i18e/src/locales/mobile/zh-CN.json
@@ -145,7 +145,17 @@
     "loginMemberFirst": "请先登录会员账号后再参与内测。",
     "cancelLogout": "取消",
     "confirmLogout": "确认",
-    "version": "AudioDock Mobile v{{version}}"
+    "version": "AudioDock Mobile v{{version}}",
+    "internalPlaybackQuality": "内网播放品质",
+    "externalPlaybackQuality": "外网播放品质",
+    "internalPlaybackQualityDescription": "内网连接时默认高品质",
+    "externalPlaybackQualityDescription": "外网连接时默认低品质",
+    "playbackQualityLossless": "无损品质",
+    "playbackQualityHigh": "高品质",
+    "playbackQualityLow": "低品质",
+    "playbackQualityLosslessDescription": "优先播放原始无损音频，流量占用最高",
+    "playbackQualityHighDescription": "优先播放高码率音频，兼顾音质和流量",
+    "playbackQualityLowDescription": "优先播放低码率音频，节省外网流量"
   },
   "player": {
     "notPlaying": "未在播放",


### PR DESCRIPTION
### Motivation
- Provide per-network playback quality preferences so internal connections default to high quality and external connections default to low quality.
- Let users change defaults from Settings on desktop and from a second-level page on mobile/mini, matching existing language-selection UX.
- Ensure the player resolves stream URLs using the configured preference (internal vs external).

### Description
- Persisted new settings fields: `internalPlaybackQuality` and `externalPlaybackQuality` on desktop/mobile stores (desktop defaults: `high` internal / `standard` external; mini exposes only `externalPlaybackQuality` defaulting to `standard`).
- Desktop Settings: added two Select controls for internal/external playback quality; mobile/mini Settings: added rows that open a second-level `PlaybackQuality` screen to pick lossless/high/low options; mini route registered in `app.config`.
- Player wiring: added `getCurrentPlaybackQualityPreference` helpers (desktop/mobile/mini variants) and applied preference when resolving track playback URLs in desktop/mobile/mini player contexts so `buildTrackPlaybackUrl` uses the chosen quality.
- Localization: added playback-quality labels and descriptions for desktop/mobile locales and created new UI files for mobile/mini selection pages and small utility modules under each platform.

### Testing
- Built shared packages successfully with `pnpm --filter @soundx/i18e build && pnpm --filter @soundx/services build && pnpm --filter @soundx/ws build` (succeeded).
- Built the desktop app bundle with `pnpm --filter sound-x build` (succeeded; production build completed for desktop artifacts).
- Ran type checks: `pnpm --dir apps/mobile exec tsc --noEmit` and `pnpm --dir apps/mini exec tsc --noEmit` both reported failures, but these are pre-existing TypeScript/Taro dependency issues unrelated to the playback-quality changes.
- Ran `git diff --check` and code style formatting on added files (no blocking diff-check issues remained).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fed21a5b1c83248a6f896f5671681e)