### PR TITLE
Fix mobile back navigation fallbacks

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,17 +1,18 @@
 import { useAuth } from "@/src/context/AuthContext";
 import { initBaseURL } from "@/src/https";
 import { check } from "@soundx/services";
-import { Stack, useSegments } from "expo-router";
+import { Stack, usePathname, useSegments } from "expo-router";
 import React, { useEffect } from "react";
 import { BackHandler } from "react-native";
 
 export default function TabLayout() {
   const { logout } = useAuth();
   const segments = useSegments();
+  const pathname = usePathname();
   const lastIndexRef = React.useRef<number | null>(null);
   const tabOrder = ["index", "library", "personal"];
 
-  const currentKey = (segments[1] as string) || "index";
+  const currentKey = ((segments as unknown as string[])[1]) || "index";
   const currentIndex = tabOrder.indexOf(currentKey);
   const prevIndex = lastIndexRef.current;
   const animation =
@@ -34,11 +35,12 @@ export default function TabLayout() {
     });
   }, []);
 
-  // 在 tab 根页面（首页/声仓/个人）拦截返回键，直接退出应用
+  // 只在真正停留在 tab 根页面（首页/声仓/个人）时退出应用。
+  // 详情页/设置页等覆盖在 tab 之上时，segments 仍可能保留 tab 信息，
+  // 因此必须用 pathname 精确判断，避免把这些页面的返回键误处理为退出应用。
   useEffect(() => {
     const backHandler = BackHandler.addEventListener("hardwareBackPress", () => {
-      const currentKey = (segments[1] as string) || "index";
-      const isTabRoot = ["index", "library", "personal"].includes(currentKey);
+      const isTabRoot = pathname === "/" || pathname === "/library" || pathname === "/personal";
       if (isTabRoot) {
         BackHandler.exitApp();
         return true;
@@ -46,7 +48,7 @@ export default function TabLayout() {
       return false;
     });
     return () => backHandler.remove();
-  }, [segments]);
+  }, [pathname]);
 
   return (
     <Stack screenOptions={{ headerShown: false, animation }}>

--- a/apps/mobile/app/admin.tsx
+++ b/apps/mobile/app/admin.tsx
@@ -12,6 +12,7 @@ import React, { useCallback, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
+  BackHandler,
   FlatList,
   StyleSheet,
   Switch,
@@ -24,6 +25,7 @@ import Modal from "react-native-modal";
 import { useTranslation } from "react-i18next";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "../src/context/ThemeContext";
+import { goBackOrReplace } from "../src/utils/navigation";
 import { User } from "../src/models";
 
 export default function AdminScreen() {
@@ -35,6 +37,15 @@ export default function AdminScreen() {
   const [loading, setLoading] = useState(false);
   const [registrationAllowed, setRegistrationAllowed] = useState(true);
   const [settingLoading, setSettingLoading] = useState(false);
+
+  React.useEffect(() => {
+    const backHandler = BackHandler.addEventListener("hardwareBackPress", () => {
+      goBackOrReplace(router, "/settings");
+      return true;
+    });
+
+    return () => backHandler.remove();
+  }, [router]);
 
   // modal states
   const [modalVisible, setModalVisible] = useState(false);
@@ -232,7 +243,7 @@ export default function AdminScreen() {
         ]}
       >
         <TouchableOpacity
-          onPress={() => router.back()}
+          onPress={() => goBackOrReplace(router, "/settings")}
           style={styles.backButton}
         >
           <Ionicons name="chevron-back" size={28} color={colors.text} />

--- a/apps/mobile/app/language.tsx
+++ b/apps/mobile/app/language.tsx
@@ -9,6 +9,9 @@ import {
 import { useRouter } from "expo-router";
 import React, { useEffect, useState } from "react";
 import {
+  BackHandler,
+  NativeModules,
+  Platform,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -17,7 +20,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../src/context/ThemeContext";
-import { Platform, NativeModules } from "react-native";
+import { goBackOrReplace } from "../src/utils/navigation";
 
 export default function LanguageScreen() {
   const router = useRouter();
@@ -25,6 +28,15 @@ export default function LanguageScreen() {
   const { colors } = useTheme();
   const { i18n, t } = useTranslation();
   const [selectedLang, setSelectedLang] = useState<string>("system");
+
+  useEffect(() => {
+    const backHandler = BackHandler.addEventListener("hardwareBackPress", () => {
+      goBackOrReplace(router, "/settings");
+      return true;
+    });
+
+    return () => backHandler.remove();
+  }, [router]);
 
   const languages = [
     { code: SYSTEM_LANGUAGE_VALUE, label: t("settings.themeSystem", "跟随系统") },
@@ -67,7 +79,7 @@ export default function LanguageScreen() {
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
         <TouchableOpacity
-          onPress={() => router.back()}
+          onPress={() => goBackOrReplace(router, "/settings")}
           style={styles.backButton}
         >
           <Ionicons name="chevron-back" size={28} color={colors.text} />

--- a/apps/mobile/app/playback-quality.tsx
+++ b/apps/mobile/app/playback-quality.tsx
@@ -1,12 +1,13 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import React from "react";
-import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { BackHandler, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useSettings } from "../src/context/SettingsContext";
 import { useTheme } from "../src/context/ThemeContext";
 import type { AudioQuality } from "../src/services/trackQuality";
+import { goBackOrReplace } from "../src/utils/navigation";
 
 const QUALITY_OPTIONS: Array<{
   value: AudioQuality;
@@ -43,19 +44,28 @@ export default function PlaybackQualityScreen() {
     ? internalPlaybackQuality
     : externalPlaybackQuality;
 
+  React.useEffect(() => {
+    const backHandler = BackHandler.addEventListener("hardwareBackPress", () => {
+      goBackOrReplace(router, "/settings");
+      return true;
+    });
+
+    return () => backHandler.remove();
+  }, [router]);
+
   const handleSelect = async (quality: AudioQuality) => {
     await updateSetting(
       isInternal ? "internalPlaybackQuality" : "externalPlaybackQuality",
       quality,
     );
-    router.back();
+    goBackOrReplace(router, "/settings");
   };
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
         <TouchableOpacity
-          onPress={() => router.back()}
+          onPress={() => goBackOrReplace(router, "/settings")}
           style={styles.backButton}
         >
           <Ionicons name="chevron-back" size={28} color={colors.text} />

--- a/apps/mobile/app/product-updates.tsx
+++ b/apps/mobile/app/product-updates.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "expo-router";
 import React, { useEffect, useState } from "react";
 import {
   ActivityIndicator,
+  BackHandler,
   ScrollView,
   StyleSheet,
   Text,
@@ -14,6 +15,7 @@ import MarkdownContent from "../src/components/MarkdownContent";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "../src/context/ThemeContext";
 import { getLocalVersion } from "../src/utils/updateUtils";
+import { goBackOrReplace } from "../src/utils/navigation";
 const qcr = require("../assets/images/wechat_qr.jpg");
 
 const GITHUB_USER = 'mmdctjj';
@@ -32,6 +34,15 @@ export default function ProductUpdatesScreen() {
   const { colors } = useTheme();
   const [loading, setLoading] = useState(true);
   const [releases, setReleases] = useState<ReleaseItem[]>([]);
+
+  useEffect(() => {
+    const backHandler = BackHandler.addEventListener("hardwareBackPress", () => {
+      goBackOrReplace(router, "/settings");
+      return true;
+    });
+
+    return () => backHandler.remove();
+  }, [router]);
 
   const fetchReleases = async () => {
     try {
@@ -120,7 +131,7 @@ export default function ProductUpdatesScreen() {
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
         <TouchableOpacity
-          onPress={() => router.back()}
+          onPress={() => goBackOrReplace(router, "/settings")}
           style={styles.backButton}
         >
           <Ionicons name="chevron-back" size={28} color={colors.text} />

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Alert,
+  BackHandler,
   ScrollView,
   StyleSheet,
   Switch,
@@ -25,6 +26,7 @@ import {
   getDetailedCacheSize,
 } from "../src/services/cache";
 import { trackEvent } from "../src/services/tracking";
+import { goBackOrReplace } from "../src/utils/navigation";
 import { usePlayMode } from "../src/utils/playMode";
 import { getLocalVersion } from "../src/utils/updateUtils";
 import { getCachedVipStatus } from "../src/utils/vipStatus";
@@ -33,6 +35,15 @@ export default function SettingsScreen() {
   const router = useRouter();
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
+
+  React.useEffect(() => {
+    const backHandler = BackHandler.addEventListener("hardwareBackPress", () => {
+      goBackOrReplace(router, "/(tabs)/personal");
+      return true;
+    });
+
+    return () => backHandler.remove();
+  }, [router]);
   const { colors, theme, toggleTheme, setTheme } = useTheme();
   const { mode, setMode } = usePlayMode();
   const { logout, user, sourceType, device, plusToken, setPlusToken } =
@@ -380,7 +391,7 @@ export default function SettingsScreen() {
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
         <TouchableOpacity
-          onPress={() => router.back()}
+          onPress={() => goBackOrReplace(router, "/(tabs)/personal")}
           style={styles.backButton}
         >
           <Ionicons name="chevron-back" size={28} color={colors.text} />

--- a/apps/mobile/src/utils/navigation.ts
+++ b/apps/mobile/src/utils/navigation.ts
@@ -1,0 +1,14 @@
+import { Router } from "expo-router";
+
+/**
+ * Go back when a route has navigation history; otherwise replace with a safe
+ * in-app fallback instead of allowing Android to fall through to app exit.
+ */
+export function goBackOrReplace(router: Router, fallback: Parameters<Router["replace"]>[0]) {
+  if (router.canGoBack()) {
+    router.back();
+    return;
+  }
+
+  router.replace(fallback);
+}


### PR DESCRIPTION
### Motivation
- Prevent Android back from exiting the app when an overlay/detail page (settings, player, etc.) is open but the tab segments still show a tab root.
- Ensure pages without navigation history (secondary pages opened directly) do not allow the back event to fall through and close the app.

### Description
- Restrict tab-root exit logic to exact paths by using `usePathname` and only calling `BackHandler.exitApp()` when `pathname` is exactly `/`, `/library`, or `/personal` (file: `apps/mobile/app/(tabs)/_layout.tsx`).
- Add a safe navigation helper `goBackOrReplace(router, fallback)` in `apps/mobile/src/utils/navigation.ts` that calls `router.back()` if history exists or `router.replace(fallback)` otherwise.
- Apply the safe fallback to settings and its secondary pages by installing `BackHandler` handlers and replacing header back actions to use `goBackOrReplace` on the following screens: `apps/mobile/app/settings.tsx`, `apps/mobile/app/language.tsx`, `apps/mobile/app/playback-quality.tsx`, `apps/mobile/app/admin.tsx`, and `apps/mobile/app/product-updates.tsx`.
- Update header/back-button handlers so hardware and UI back actions navigate back through settings/personal instead of exiting the app.

### Testing
- Ran `pnpm --filter mobile exec tsc --noEmit`; command failed with existing workspace type/import issues (unresolved `@soundx/i18e`, `@soundx/ws`, socket typings, and other pre-existing TypeScript errors), and no new type errors attributable to these changes were introduced.
- Ran `pnpm --filter mobile lint`; lint returned existing unresolved import errors and multiple pre-existing warnings, so CI/lint did not pass but failures are unrelated to the navigation logic changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aef38be908321a0365958fb5a8ad4)