### PR TITLE
Fix Docker pnpm frozen install mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,15 @@
 # ==========================================
 FROM node:22-bullseye AS builder
 
+ARG PNPM_VERSION=10.28.1
+
 RUN apt-get update \
   && apt-get install -y openssl \
   && rm -rf /var/lib/apt/lists/*
 
 # Use China registry mirror for faster/more reliable installs in builder stage too.
 RUN npm config set registry https://registry.npmmirror.com \
-  && npm install -g pnpm \
+  && npm install -g pnpm@${PNPM_VERSION} \
   && pnpm config set registry https://registry.npmmirror.com
 WORKDIR /app
 
@@ -24,6 +26,10 @@ COPY packages/ws/package.json ./packages/ws/
 COPY packages/services/package.json ./packages/services/
 COPY services/api/package.json ./services/api/
 COPY apps/desktop/package.json ./apps/desktop/
+COPY apps/mini/package.json ./apps/mini/
+COPY apps/mobile/package.json ./apps/mobile/
+COPY packages/test/package.json ./packages/test/
+COPY packages/ui/package.json ./packages/ui/
 
 # 3. 安装依赖
 RUN pnpm install --frozen-lockfile
@@ -51,6 +57,8 @@ RUN cd apps/desktop && pnpm run build:web
 # Stage 2: Unified Runner (All-in-one image)
 # ==========================================
 FROM node:22-bullseye-slim AS runner
+
+ARG PNPM_VERSION=10.28.1
 
 WORKDIR /app
 
@@ -101,7 +109,7 @@ RUN python3 -m pip install --no-cache-dir -r /app/services/asr/requirements.txt
 # Use China registry mirror for faster/more reliable installs.
 # pnpm will also use this registry once configured.
 RUN npm config set registry https://registry.npmmirror.com \
-    && npm install -g pnpm \
+    && npm install -g pnpm@${PNPM_VERSION} \
     && pnpm config set registry https://registry.npmmirror.com \
     && pnpm install --prod --frozen-lockfile --ignore-scripts
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "soundX",
   "version": "1.1.13",
+  "packageManager": "pnpm@10.28.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  esbuild: 0.21.4
+  esbuild: '0.21.4'
 
 importers:
 


### PR DESCRIPTION
### Motivation
- The Docker build failed on `pnpm install --frozen-lockfile` due to a lockfile vs runtime pnpm/config mismatch (`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`).
- The builder image installed whatever `pnpm` was latest, and the Docker build step copied an incomplete set of workspace manifests before running `pnpm install`, causing the workspace shape and overrides types to differ from the lockfile.

### Description
- Pin `pnpm` in both Docker stages by adding `ARG PNPM_VERSION` and installing `pnpm@${PNPM_VERSION}` in the builder and runner stages of the `Dockerfile` so the same pnpm version is used during builds.
- Copy additional workspace `package.json` manifests (apps/mini, apps/mobile, packages/test, packages/ui) into the build context before running `pnpm install` so the manifest-only install context matches the lockfile importers.
- Add `packageManager: "pnpm@10.28.1"` to the root `package.json` so local/CI/Docker use the same package manager version.
- Quote the `esbuild` override in `pnpm-lock.yaml` (`esbuild: '0.21.4'`) to match the string form used in `package.json` and avoid type/semantic mismatch during frozen installs.

### Testing
- Ran `pnpm install --frozen-lockfile` in the repository and it completed successfully (using `pnpm v10.28.1`).
- Simulated the Docker manifest-only install context by copying only `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml` and all workspace manifests into a temp dir and ran `pnpm install --frozen-lockfile`, which succeeded.
- Verified `package.json` JSON validity with `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` and checked `pnpm-lock.yaml` overrides parsed via Python YAML (override is now a string).
- Attempted to run an actual `docker build` but the environment lacks Docker (`docker: command not found`), so full image build was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0af6e526e48321bb86c04ad1bedcd0)