### PR TITLE
Refresh audiobook resume points from history before playback (desktop/mini/mobile)

### DIFF
--- a/apps/desktop/src/components/Cover/index.tsx
+++ b/apps/desktop/src/components/Cover/index.tsx
@@ -9,6 +9,7 @@ import {
 import {
   addAlbumToCollection,
   createCollection,
+  getAlbumHistory,
   getAlbumById,
   getAlbumTracks,
   getCollectionMembership,
@@ -150,6 +151,23 @@ const Cover: CoverComponent = ({
       setPlaylist([item as Track]);
     } else {
       try {
+        let resumeTrackId = (item as any).resumeTrackId;
+        let resumeProgress = (item as any).resumeProgress || 0;
+        if (isHistory && user?.id) {
+          try {
+            const historyRes = await getAlbumHistory(user.id, 0, 50, "AUDIOBOOK");
+            const matched = historyRes?.data?.list?.find(
+              (entry: any) => String(entry?.album?.id) === String((item as Album).id),
+            );
+            if (matched) {
+              resumeTrackId = matched.trackId ?? resumeTrackId;
+              resumeProgress = matched.progress ?? resumeProgress;
+            }
+          } catch (e) {
+            console.warn("Failed to refresh latest audiobook resume point:", e);
+          }
+        }
+
         const pageSize = 50;
         const res = await getAlbumTracks((item as Album).id, pageSize, 0);
         if (res.code === 200 && res.data.list.length > 0) {
@@ -166,9 +184,6 @@ const Cover: CoverComponent = ({
           });
 
           // Check for resume info
-          const resumeTrackId = (item as any).resumeTrackId;
-          const resumeProgress = (item as any).resumeProgress;
-
           let targetTrack = tracks[0];
           let startTime = 0;
 

--- a/apps/mini/src/pages/index/index.tsx
+++ b/apps/mini/src/pages/index/index.tsx
@@ -18,6 +18,30 @@ export default function Index() {
   const [sections, setSections] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
 
+  const getLatestResumePoint = async (
+    albumId: number | string,
+    fallbackTrackId?: number | string,
+    fallbackProgress?: number,
+  ) => {
+    let resumeTrackId = fallbackTrackId
+    let resumeProgress = fallbackProgress || 0
+    if (user?.id) {
+      try {
+        const historyRes = await getAlbumHistory(user.id, 0, 8, 'AUDIOBOOK')
+        const matched = historyRes?.data?.list?.find(
+          (entry: any) => String(entry?.album?.id) === String(albumId)
+        )
+        if (matched) {
+          resumeTrackId = matched.trackId ?? resumeTrackId
+          resumeProgress = matched.progress ?? resumeProgress
+        }
+      } catch (e) {
+        console.warn('Failed to refresh latest audiobook resume point:', e)
+      }
+    }
+    return { resumeTrackId, resumeProgress }
+  }
+
   const loadData = async () => {
     setLoading(true)
     try {
@@ -228,8 +252,13 @@ export default function Index() {
                                 }
 
                                 if (section.id === 'history') {
-                                  const resumeTrackId = item.resumeTrackId;
-                                  const resumeProgress = item.resumeProgress;
+                                  const latest = await getLatestResumePoint(
+                                    item.id,
+                                    item.resumeTrackId,
+                                    item.resumeProgress
+                                  );
+                                  const resumeTrackId = latest.resumeTrackId;
+                                  const resumeProgress = latest.resumeProgress;
 
                                   if (resumeTrackId) {
                                     try {

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -202,6 +202,32 @@ export default function HomeScreen() {
   const isTablet = Device.deviceType === Device.DeviceType.TABLET;
   const pageSize = !isTablet ? 8 : 16;
   const recommendCacheKey = `home_sections_${mode}_${recommendationLikeRatio}`;
+  const getLatestResumePoint = useCallback(
+    async (
+      albumId: number | string,
+      fallbackTrackId?: number | string,
+      fallbackProgress?: number,
+    ) => {
+      let resumeTrackId = fallbackTrackId;
+      let resumeProgress = fallbackProgress || 0;
+      if (user?.id) {
+        try {
+          const historyRes = await getAlbumHistory(user.id, 0, pageSize, "AUDIOBOOK");
+          const matched = historyRes?.data?.list?.find(
+            (entry: any) => String(entry?.album?.id) === String(albumId),
+          );
+          if (matched) {
+            resumeTrackId = matched.trackId ?? resumeTrackId;
+            resumeProgress = matched.progress ?? resumeProgress;
+          }
+        } catch (e) {
+          console.warn("Failed to refresh latest audiobook resume point:", e);
+        }
+      }
+      return { resumeTrackId, resumeProgress };
+    },
+    [user?.id, pageSize],
+  );
 
   const loadData = useCallback(
     async (forceRefresh = false) => {
@@ -789,8 +815,13 @@ export default function HomeScreen() {
                         onPress={async () => {
                           // Only 'history' section supports direct resume playback
                           if (section.id === "history") {
-                            const resumeTrackId = (item as any).resumeTrackId;
-                            const resumeProgress = (item as any).resumeProgress;
+                            const latest = await getLatestResumePoint(
+                              item.id,
+                              (item as any).resumeTrackId,
+                              (item as any).resumeProgress,
+                            );
+                            const resumeTrackId = latest.resumeTrackId;
+                            const resumeProgress = latest.resumeProgress;
 
                             if (resumeTrackId) {
                               try {


### PR DESCRIPTION
### Motivation

- Ensure audiobook resume playback uses the latest server-side history so users resume at the most recent track/position rather than stale metadata.

### Description

- Added `getAlbumHistory` import and logic in the desktop `Cover` component `handlePlayAlbum` to fetch the latest history for `AUDIOBOOK` items when `isHistory` and merge `trackId`/`progress` into resume data before loading tracks and playing.  
- Introduced a `getLatestResumePoint` helper in the mini `pages/index` and mobile `(tabs)/index` to query `getAlbumHistory` and override `resumeTrackId`/`resumeProgress` for history items prior to attempting resume playback.  
- Updated click/play handlers in mini and mobile to call the helper and use the returned `resumeTrackId`/`resumeProgress` when available, falling back to existing item fields if not.

### Testing

- Ran TypeScript type checking with `tsc --noEmit` and local builds for the affected targets, which completed successfully.  
- Executed the repository's automated test suite and CI checks (unit/type/lint) which passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1001c84a04832bafa0c2d0d4c6ef1b)