### PR TITLE
fix: 统一 Desktop/Mobile 曲目进度上报逻辑

### DIFF
--- a/apps/desktop/src/store/player.ts
+++ b/apps/desktop/src/store/player.ts
@@ -139,8 +139,9 @@ export const usePlayerStore = create<PlayerState>((set, get) => {
   const storedVolume = Number(localStorage.getItem("playerVolume")) || 70;
 
   // Progress Reporting Helper
-  let lastReportTime = 0;
-  const ATTEMPT_REPORT_INTERVAL = 5; // Seconds (unified with Mobile)
+  let lastReportTime = 0; // Date.now() timestamp
+  let lastReportedPosition = 0;
+  const ATTEMPT_REPORT_INTERVAL = 5000; // ms (unified with Mobile)
 
   const reportProgress = (state: PlayerState, force = false) => {
     const { currentTrack, currentTime, isPlaying, activeMode } = state;
@@ -150,8 +151,12 @@ export const usePlayerStore = create<PlayerState>((set, get) => {
     const roundedTime = Math.floor(currentTime);
     if (roundedTime <= 0) return;
 
-    // Report if forced (e.g. pause/change) or interval met
-    if (force || (isPlaying && Math.abs(roundedTime - lastReportTime) >= ATTEMPT_REPORT_INTERVAL)) {
+    const now = Date.now();
+    const timeElapsed = now - lastReportTime >= ATTEMPT_REPORT_INTERVAL;
+    const positionChanged = Math.abs(roundedTime - lastReportedPosition) >= 5;
+
+    // Report if forced (e.g. pause/change) or interval met and position changed
+    if (force || (isPlaying && timeElapsed && positionChanged)) {
       const userId = useAuthStore.getState().user?.id;
       if (!userId) return;
 
@@ -160,7 +165,8 @@ export const usePlayerStore = create<PlayerState>((set, get) => {
         trackId: currentTrack.id,
         progress: roundedTime
       }).catch(e => console.error("Failed to report progress", e));
-      lastReportTime = roundedTime;
+      lastReportTime = now;
+      lastReportedPosition = roundedTime;
 
       // Sync progress to local playlist and currentTrack
       const updatedPlaylist = state.playlist.map(t =>
@@ -452,7 +458,10 @@ export const usePlayerStore = create<PlayerState>((set, get) => {
 
         const userId = useAuthStore.getState().user?.id;
         if (userId) {
-          addToHistory(Number(nextTrack.id), userId).catch(console.error);
+          const deviceName =
+            (await window.ipcRenderer?.getName()) || window.navigator.userAgent;
+          const device = JSON.parse(localStorage.getItem("device") || "{}");
+          addToHistory(Number(nextTrack.id), userId, 0, deviceName, device.id).catch(console.error); // fix: progress report fix
         }
       }
       get()._saveCurrentStateToMode();
@@ -480,9 +489,12 @@ export const usePlayerStore = create<PlayerState>((set, get) => {
       reportProgress(get(), true);
 
       const userId = useAuthStore.getState().user?.id;
-        if (userId) {
-          addToHistory(Number(prevTrack.id), userId).catch(console.error);
-        }
+      if (userId) {
+        const deviceName =
+          (await window.ipcRenderer?.getName()) || window.navigator.userAgent;
+        const device = JSON.parse(localStorage.getItem("device") || "{}");
+        addToHistory(Number(prevTrack.id), userId, 0, deviceName, device.id).catch(console.error); // fix: progress report fix
+      }
 
       get()._saveCurrentStateToMode();
     },

--- a/apps/mobile/src/context/PlayerContext.tsx
+++ b/apps/mobile/src/context/PlayerContext.tsx
@@ -1724,6 +1724,16 @@ export const PlayerProvider: React.FC<{ children: React.ReactNode }> = ({
         }
         
         lastReportTimeRef.current = now;
+        // fix: sync local progress after report
+        const reportedProgress = currentTime;
+        if (currentTrackRef.current) {
+          currentTrackRef.current = { ...currentTrackRef.current, progress: reportedProgress };
+          setCurrentTrack(currentTrackRef.current);
+        }
+        const updatedTrackList = trackListRef.current.map(t =>
+          t.id === currentTrackRef.current?.id ? { ...t, progress: reportedProgress } : t
+        );
+        setTrackList(updatedTrackList);
       } catch (e) {
         console.log(
           "Background history sync skipped due to network/transient error"


### PR DESCRIPTION
Desktop:
- reportProgress 改用 Date.now() + lastReportedPosition 防 seek 误报
- next()/prev() 补齐 addToHistory 完整参数 (progress, deviceName, deviceId)

Mobile:
- recordHistory 成功后同步更新 currentTrack.progress + trackList

Refs: audiodock_progress_analysis.md