### PR TITLE
fix(api): serve transcoded mp3 playback

### DIFF
--- a/services/api/src/main.ts
+++ b/services/api/src/main.ts
@@ -22,11 +22,13 @@ async function bootstrap() {
 
 
   const cacheDir = path.resolve(process.env.CACHE_DIR || DEFAULT_CACHE_DIR);
+  const transcodedAudioDir = path.join(cacheDir, 'transcoded-audio');
   const transcodedMvDir = path.join(cacheDir, 'transcoded-mv');
   const musicBaseDirs = resolvePathList(process.env.MUSIC_BASE_DIR, DEFAULT_MUSIC_DIR);
   const audioBookDirs = resolvePathList(process.env.AUDIO_BOOK_DIR, DEFAULT_AUDIOBOOK_DIR);
   const mvDirs = resolvePathList(process.env.MV_BASE_DIR, DEFAULT_MV_DIR);
 
+  fs.mkdirSync(transcodedAudioDir, { recursive: true });
   fs.mkdirSync(transcodedMvDir, { recursive: true });
 
 
@@ -36,6 +38,10 @@ async function bootstrap() {
   console.log(`Serving static files from: ${cacheDir}`);
   app.useStaticAssets(cacheDir, {
     prefix: '/covers/',
+    setHeaders: (res, filePath) => {
+      res.set('Accept-Ranges', 'bytes');
+      if (filePath.endsWith('.mp3')) res.set('Content-Type', 'audio/mpeg');
+    },
   });
 
   // Serve music files

--- a/services/api/src/services/track.ts
+++ b/services/api/src/services/track.ts
@@ -4,7 +4,7 @@ import { FileStatus, PrismaClient, Track, TrackType } from '@soundx/db';
 import { spawn } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { DEFAULT_AUDIOBOOK_DIR, DEFAULT_MUSIC_DIR } from '../common/media-paths';
+import { DEFAULT_AUDIOBOOK_DIR, DEFAULT_CACHE_DIR, DEFAULT_MUSIC_DIR } from '../common/media-paths';
 import { getTrackHeartbeatScoreMap } from './heartbeat-score';
 import { toSimplified } from '../common/zh-utils';
 import { resolvePathList } from '../common/path-list';
@@ -74,6 +74,12 @@ export class TrackService {
         if (candidate) return candidate;
       }
       return path.join(audioBookDirs[0], relativePath);
+    }
+    if (trackPath.startsWith('/covers/')) {
+      const cacheDir = path.resolve(this.configService.get<string>('CACHE_DIR') || DEFAULT_CACHE_DIR);
+      const relativePath = trackPath.replace('/covers/', '');
+      const candidate = this.resolveCandidatePath(cacheDir, relativePath);
+      return candidate || path.join(cacheDir, relativePath);
     }
     return null;
   }


### PR DESCRIPTION
### Motivation
- Transcoded MP3s were stored under the API cache (e.g. `/covers/transcoded-audio/... .mp3`) but the server and TrackService did not properly expose or resolve those files, causing the desktop player to fail to play some converted formats.
- The static asset serving for cache files lacked range support and an explicit `audio/mpeg` content type for `.mp3`, which breaks playback in Electron/desktop clients.

### Description
- Ensure the `transcoded-audio` cache directory is created at startup so pre-transcoded MP3s always have a place to land (`services/api/src/main.ts`).
- Serve cache files under `/covers/` with `Accept-Ranges: bytes` and set `.mp3` responses to `Content-Type: audio/mpeg` to enable range requests and correct MIME detection (`services/api/src/main.ts`).
- Make `TrackService.getFilePath()` resolve `/covers/*` paths against `CACHE_DIR` (or `DEFAULT_CACHE_DIR`) so tracks whose stored `path` points to `/covers/transcoded-audio/...` map back to the real filesystem file and can be streamed (`services/api/src/services/track.ts`).

### Testing
- Built the DB package with `pnpm --filter @soundx/db run build` (succeeded).
- Built the utils package with `pnpm --filter @soundx/utils run build` (succeeded).
- Built the API with `pnpm --filter api run build`; the API build initially failed until workspace packages were built, and after building dependencies the API build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199d601e748321869ad68a7c9e99ba)